### PR TITLE
Add latest version of Tika #7

### DIFF
--- a/cmd/tika/main.go
+++ b/cmd/tika/main.go
@@ -54,12 +54,11 @@ const (
 
 // Command line flags.
 var (
-	downloadVersion = flag.String("download_version", "", "Tika Server JAR version to download. If -serverJAR is specified, it will be downloaded to that location, otherwise it will be downloaded to your working directory. If the JAR has already been downloaded and has the correct MD5, this will do nothing. Valid versions: 1.14.")
-	filename        = flag.String("filename", "", "Path to file to parse.")
-	metaField       = flag.String("field", "", `Specific field to get when using the "meta" action. Undefined when using the -recursive flag.`)
-	recursive       = flag.Bool("recursive", false, `Whether to run "parse" or "meta" recursively, returning a list with one element per embedded document. Undefined when using the -field flag.`)
-	serverJAR       = flag.String("server_jar", "", "Absolute path to the Tika Server JAR. This will start a new server, ignoring -serverURL.")
-	serverURL       = flag.String("server_url", "", "URL of Tika server.")
+	filename  = flag.String("filename", "", "Path to file to parse.")
+	metaField = flag.String("field", "", `Specific field to get when using the "meta" action. Undefined when using the -recursive flag.`)
+	recursive = flag.Bool("recursive", false, `Whether to run "parse" or "meta" recursively, returning a list with one element per embedded document. Undefined when using the -field flag.`)
+	serverJAR = flag.String("server_jar", "", "Absolute path to the Tika Server JAR. This will start a new server, ignoring -serverURL.")
+	serverURL = flag.String("server_url", "", "URL of Tika server.")
 )
 
 func main() {
@@ -71,25 +70,13 @@ func main() {
 	}
 	action := flag.Arg(0)
 
-	if *downloadVersion != "" {
-		v := tika.Version116
-		switch *downloadVersion {
-		case "1.14":
-			v = tika.Version114
-		case "1.15":
-			v = tika.Version115
-		case "1.16":
-			v = tika.Version116
-		default:
-			log.Fatalf("unsupported server version: %q", *downloadVersion)
-		}
-		if *serverJAR == "" {
-			*serverJAR = "tika-server-" + *downloadVersion + ".jar"
-		}
-		err := tika.DownloadServer(context.Background(), v, *serverJAR)
-		if err != nil {
-			log.Fatal(err)
-		}
+	v := tika.Version119
+	if *serverJAR == "" {
+		*serverJAR = "tika-server-" + string(v) + ".jar"
+	}
+	err := tika.DownloadServer(context.Background(), v, *serverJAR)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	if *serverURL == "" && *serverJAR == "" {

--- a/tika/server.go
+++ b/tika/server.go
@@ -18,7 +18,7 @@ package tika
 
 import (
 	"context"
-	"crypto"
+	"crypto/sha512"
 	"fmt"
 	"io"
 	"net/url"
@@ -123,14 +123,14 @@ func (s *Server) Stop() error {
 	return nil
 }
 
-func getHash(path string, alg crypto.Hash) (string, error) {
+func sha512Hash(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
 
-	h := alg.New()
+	h := sha512.New()
 	if _, err := io.Copy(h, f); err != nil {
 		return "", err
 	}
@@ -142,43 +142,25 @@ type version string
 
 // Supported versions of Tika Server.
 const (
-	Version114 version = "1.14"
-	Version115 version = "1.15"
-	Version116 version = "1.16"
-	Version117 version = "1.17"
-	Version118 version = "1.18"
 	Version119 version = "1.19"
 )
 
-var md5s = map[version]string{
-	Version114: "39055fc71358d774b9da066f80b1141c",
-	Version115: "80bd3f00f05326d5190466de27d593dd",
-	Version116: "6a549ce6ef6e186e019766059fd82fb2",
-	Version117: "788cf50d9e7ec3de0d66541e560fbe00",
-}
-
 var sha512s = map[version]string{
-	Version118: "e44e015590738592e5ed4d60d2360f54b4830e2a22eb8533d969582f90cce7984f93f3efbb53c14fd2c6f34bf4486b142a1ca2847d88f2270f89bec43955acb3",
-	Version119: "b9d087b38c22bc16b73e4c3d5f66c752e601efa6a82105572c6a2359e119c2442c6d5eaa5270c29d040ecace398b570d02fdd3b112b495775f67122066614a47",
+	Version119: "a9e2b6186cdb9872466d3eda791d0e1cd059da923035940d4b51bb1adc4a356670fde46995725844a2dd500a09f3a5631d0ca5fbc2d61a59e8e0bd95c9dfa6c2",
 }
 
 // DownloadServer downloads and validates the given server version,
 // saving it at path. DownloadServer returns an error if it could
-// not be downloaded/validated. Valid values for the version are 1.14.
+// not be downloaded/validated. Valid values for the version are 1.19.
 // It is the caller's responsibility to remove the file when no longer needed.
-// If the file already exists and has the correct MD5, DownloadServer will
+// If the file already exists and has the correct sha512, DownloadServer will
 // do nothing.
 func DownloadServer(ctx context.Context, v version, path string) error {
 	hash := sha512s[v]
-	alg := crypto.SHA512
 	if hash == "" {
-		hash = md5s[v]
-		if hash == "" {
-			return fmt.Errorf("unsupported Tika version: %s", v)
-		}
-		alg = crypto.MD5
+		return fmt.Errorf("unsupported Tika version: %s", v)
 	}
-	if got, err := getHash(path, alg); err == nil {
+	if got, err := sha512Hash(path); err == nil {
 		if got == hash {
 			return nil
 		}
@@ -200,16 +182,16 @@ func DownloadServer(ctx context.Context, v version, path string) error {
 		return fmt.Errorf("error saving download: %v", err)
 	}
 
-	h, err := getHash(path, alg)
+	h, err := sha512Hash(path)
 
 	if err != nil {
 		return err
 	}
 	if h != hash {
 		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("invalid ckecksum: %s: error removing %s: %v", h, path, err)
+			return fmt.Errorf("invalid sha512: %s: error removing %s: %v", h, path, err)
 		}
-		return fmt.Errorf("invalid checksum: %s", h)
+		return fmt.Errorf("invalid sha512: %s", h)
 	}
 	return nil
 }

--- a/tika/server_test.go
+++ b/tika/server_test.go
@@ -18,6 +18,7 @@ package tika
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -186,7 +187,7 @@ func TestHelperProcess(*testing.T) {
 	}
 }
 
-func TestValidateFileMD5(t *testing.T) {
+func TestValidateFileHash(t *testing.T) {
 	path, err := os.Executable()
 	if err != nil {
 		t.Skip("cannot find current test executable")
@@ -200,13 +201,13 @@ func TestValidateFileMD5(t *testing.T) {
 		{path, false},
 	}
 	for _, test := range tests {
-		_, err := md5Hash(test.path)
+		_, err := getHash(test.path, crypto.MD5)
 		if test.wantErr && err == nil {
-			t.Errorf("md5Hash(%s) wanted an error", test.path)
+			t.Errorf("getHash(%s) wanted an error", test.path)
 			continue
 		}
 		if !test.wantErr && err != nil {
-			t.Errorf("md5Hash(%s) got an error: %v", test.path, err)
+			t.Errorf("getHash(%s) got an error: %v", test.path, err)
 		}
 	}
 }

--- a/tika/server_test.go
+++ b/tika/server_test.go
@@ -18,7 +18,6 @@ package tika
 
 import (
 	"context"
-	"crypto"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -201,7 +200,7 @@ func TestValidateFileHash(t *testing.T) {
 		{path, false},
 	}
 	for _, test := range tests {
-		_, err := getHash(test.path, crypto.MD5)
+		_, err := sha512Hash(test.path)
 		if test.wantErr && err == nil {
 			t.Errorf("getHash(%s) wanted an error", test.path)
 			continue


### PR DESCRIPTION
#7 
I added several version of apatch tika which can check main version in 
https://archive.apache.org/dist/tika/

over v 1.18, I cannot find md5 checksum so that I added and implement to check sha512 sum. if it looks good to you, please review and merge this PR.