### PR TITLE
added a graceful shutdown method, added -spawnChild mode

### DIFF
--- a/cmd/tika/main.go
+++ b/cmd/tika/main.go
@@ -54,7 +54,7 @@ const (
 
 // Command line flags.
 var (
-	downloadVersion = flag.String("download_version", "", "Tika Server JAR version to download. If -serverJAR is specified, it will be downloaded to that location, otherwise it will be downloaded to your working directory. If the JAR has already been downloaded and has the correct MD5, this will do nothing. Valid versions: 1.19.")
+	downloadVersion = flag.String("download_version", "", fmt.Sprintf("Tika Server JAR version to download. If -serverJAR is specified, it will be downloaded to that location, otherwise it will be downloaded to your working directory. If the JAR has already been downloaded and has the correct MD5, this will do nothing. Valid versions: %v.", tika.Versions))
 	filename        = flag.String("filename", "", "Path to file to parse.")
 	metaField       = flag.String("field", "", `Specific field to get when using the "meta" action. Undefined when using the -recursive flag.`)
 	recursive       = flag.Bool("recursive", false, `Whether to run "parse" or "meta" recursively, returning a list with one element per embedded document. Undefined when using the -field flag.`)
@@ -72,18 +72,22 @@ func main() {
 	action := flag.Arg(0)
 
 	if *downloadVersion != "" {
-		v := tika.Version119
-		switch *downloadVersion {
-		case "1.19":
-			v = tika.Version119
-		default:
+		v := tika.Versions[len(tika.Versions) - 1]
+		supported := false
+		for _, sv := range tika.Versions {
+			if tika.Version(*downloadVersion) == sv {
+				v = tika.Version(*downloadVersion)
+				supported = true
+				break
+			}
+		}
+		if !supported {
 			log.Fatalf("unsupported server version: %q", *downloadVersion)
 		}
 		if *serverJAR == "" {
 			*serverJAR = "tika-server-" + string(v) + ".jar"
 		}
-		err := tika.DownloadServer(context.Background(), v, *serverJAR)
-		if err != nil {
+		if err := tika.DownloadServer(context.Background(), v, *serverJAR); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/tika/server.go
+++ b/tika/server.go
@@ -53,7 +53,7 @@ type ChildOptions struct {
 	PingTimeoutMillis int
 }
 
-func (co *ChildOptions) getArgs() []string {
+func (co *ChildOptions) args() []string {
 	if co == nil {
 		return []string{}
 	}

--- a/tika/server.go
+++ b/tika/server.go
@@ -78,7 +78,7 @@ func NewServer(jar, port string) (*Server, error) {
 }
 
 // ChildMode sets up the server to use the -spawnChild option
-// must be called before starting the server
+// If used, ChildMode must be called before starting the server.
 func (s *Server) ChildMode(maxfiles, taskpulse, tasktimeout, pingpulse, pingtimeout int) error {
 	if s.cmd != nil {
 		return fmt.Errorf("Server Process already started, cannot switch to spawn child mode")

--- a/tika/server.go
+++ b/tika/server.go
@@ -137,25 +137,32 @@ func sha512Hash(path string) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-// A version represents a Tika Server version.
-type version string
+// A Version represents a Tika Server version.
+type Version string
 
 // Supported versions of Tika Server.
 const (
-	Version119 version = "1.19"
+	Version119 Version = "1.19"
+	Version120 Version = "1.20"
+	Version121 Version = "1.21"
 )
 
-var sha512s = map[version]string{
+// Versions is a list of supported versions of Apache Tika.
+var Versions = []Version{Version119, Version120, Version121}
+
+var sha512s = map[Version]string{
 	Version119: "a9e2b6186cdb9872466d3eda791d0e1cd059da923035940d4b51bb1adc4a356670fde46995725844a2dd500a09f3a5631d0ca5fbc2d61a59e8e0bd95c9dfa6c2",
+	Version120: "a7ef35317aba76be8606f9250893efece8b93384e835a18399da18a095b19a15af591e3997828d4ebd3023f21d5efad62a91918610c44e692cfd9bed01d68382",
+	Version121: "e705c836b2110530c8d363d05da27f65c4f6c9051b660cefdae0e5113c365dbabed2aa1e4171c8e52dbe4cbaa085e3d8a01a5a731e344942c519b85836da646c",
 }
 
 // DownloadServer downloads and validates the given server version,
 // saving it at path. DownloadServer returns an error if it could
-// not be downloaded/validated. Valid values for the version are 1.19.
+// not be downloaded/validated.
 // It is the caller's responsibility to remove the file when no longer needed.
 // If the file already exists and has the correct sha512, DownloadServer will
 // do nothing.
-func DownloadServer(ctx context.Context, v version, path string) error {
+func DownloadServer(ctx context.Context, v Version, path string) error {
 	hash := sha512s[v]
 	if hash == "" {
 		return fmt.Errorf("unsupported Tika version: %s", v)

--- a/tika/server.go
+++ b/tika/server.go
@@ -83,7 +83,10 @@ func (s *Server) ChildMode(maxfiles, taskpulse, tasktimeout, pingpulse, pingtime
 	if s.cmd != nil {
 		return fmt.Errorf("Server Process already started, cannot switch to spawn child mode")
 	}
-	co := new(childOptions)
+	co := &childOptions{
+		maxFiles: strconv.Itoa(maxFiles),
+		// ...
+	}
 	co.maxFiles = strconv.Itoa(maxfiles)
 	co.taskPulseMillis = strconv.Itoa(taskpulse)
 	co.taskTimeoutMillis = strconv.Itoa(tasktimeout)

--- a/tika/server.go
+++ b/tika/server.go
@@ -108,7 +108,7 @@ func NewServer(jar, port string) (*Server, error) {
 // If you want to turn off the -spawnChild option, call Server.ChildMode(nil).
 func (s *Server) ChildMode(ops *ChildOptions) error {
 	if s.cmd != nil {
-		return fmt.Errorf("Server Process already started, cannot switch to spawn child mode")
+		return fmt.Errorf("server process already started, cannot switch to spawn child mode")
 	}
 	s.child = ops
 	return nil

--- a/tika/server.go
+++ b/tika/server.go
@@ -55,7 +55,7 @@ type ChildOptions struct {
 
 func (co *ChildOptions) args() []string {
 	if co == nil {
-		return []string{}
+		return nil
 	}
 	args := []string{}
 	args = append(args, "-spawnChild")
@@ -121,7 +121,7 @@ var command = exec.Command
 // Server. Start will wait for the server to be available or until ctx is
 // cancelled.
 func (s *Server) Start(ctx context.Context) error {
-	cmd := command("java", append([]string{"-jar", s.jar, "-p", s.port}, s.child.getArgs()...)...)
+	cmd := command("java", append([]string{"-jar", s.jar, "-p", s.port}, s.child.args()...)...)
 
 	if err := cmd.Start(); err != nil {
 		return err
@@ -160,6 +160,8 @@ func (s Server) waitForStart(ctx context.Context) error {
 // Stop shuts the server down, killing the underlying Java process. Stop
 // must be called when finished with the server to avoid leaking the
 // Java process. If s has not been started, Stop will panic.
+// If not running in a Windows environment, it is recommended to use Shutdown
+// for a more graceful shutdown of the Java process.
 func (s *Server) Stop() error {
 	if err := s.cmd.Process.Kill(); err != nil {
 		return fmt.Errorf("could not kill server: %v", err)

--- a/tika/server.go
+++ b/tika/server.go
@@ -44,7 +44,7 @@ type Server struct {
 }
 
 // Command line parameters that can be used when tika is run with the -spawnChild option.
-// If field is 0 associated flag is not included.
+// If a field is less than or equal to 0, the associated flag is not included.
 type ChildOptions struct {
 	MaxFiles int
 	TaskPulseMillis int

--- a/tika/server.go
+++ b/tika/server.go
@@ -43,7 +43,7 @@ type Server struct {
 	child *ChildOptions
 }
 
-// Command line parameters that can be used when tika is run with the -spawnChild option.
+// ChildOptions represent command line parameters that can be used when Tika is run with the -spawnChild option.
 // If a field is less than or equal to 0, the associated flag is not included.
 type ChildOptions struct {
 	MaxFiles int

--- a/tika/server.go
+++ b/tika/server.go
@@ -57,7 +57,7 @@ func (co *ChildOptions) args() []string {
 	if co == nil {
 		return []string{}
 	}
-	args := make([]string, 0, 11)
+	args := []string{}
 	args = append(args, "-spawnChild")
 	if co.MaxFiles == -1 || co.MaxFiles > 0 {
 		args = append(args, "-maxFiles", strconv.Itoa(co.MaxFiles))


### PR DESCRIPTION
Should be backwards compatible with previous versions of package

Running with the spawnChild option makes Tika Server Robust to OOMs, Infinite Loops and Memory Leaks: https://cwiki.apache.org/confluence/display/tika/TikaJAXRS#TikaJAXRS-MakingTikaServerRobusttoOOMs,InfiniteLoopsandMemoryLeaks