### PR TITLE
Function to set Tika's temporaty work location when starting server

### DIFF
--- a/tika/doc.go
+++ b/tika/doc.go
@@ -43,6 +43,10 @@ If you don't have a running Tika Server, you can start one.
 	}
 	defer s.Stop()
 
+
+You can also start a Tika Server with a temporary workspace other than /tmp
+	err := s.StartWithAltTmp(context.Background(), "/content/tmp/tika/")
+
 To parse the contents of a file (or any io.Reader), you will need to open the io.Reader,
 create a client, and call client.Parse.
 

--- a/tika/server.go
+++ b/tika/server.go
@@ -24,8 +24,8 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"time"
 	"strconv"
+	"time"
 
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -36,20 +36,20 @@ import (
 // There is no need to create a Server for an already running Tika Server
 // since you can pass its URL directly to a Client.
 type Server struct {
-	jar  string
-	url  string // url is derived from port.
-	port string
-	cmd  *exec.Cmd
+	jar   string
+	url   string // url is derived from port.
+	port  string
+	cmd   *exec.Cmd
 	child *ChildOptions
 }
 
 // ChildOptions represent command line parameters that can be used when Tika is run with the -spawnChild option.
 // If a field is less than or equal to 0, the associated flag is not included.
 type ChildOptions struct {
-	MaxFiles int
-	TaskPulseMillis int
+	MaxFiles          int
+	TaskPulseMillis   int
 	TaskTimeoutMillis int
-	PingPulseMillis int
+	PingPulseMillis   int
 	PingTimeoutMillis int
 }
 
@@ -143,7 +143,7 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 //Starts the server as above with an additional argument to set an alternate temp location
-func (s *Server) StartWithAltTemp(ctx context.Context, tmp string) error {
+func (s *Server) StartWithAltTmp(ctx context.Context, tmp string) error {
 
 	if tmp == "" {
 		tmp = "/tmp"
@@ -215,13 +215,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	}
 	errChannel := make(chan error)
 	go func() {
-			select {
-			case errChannel <- s.cmd.Wait():
-			case <-ctx.Done():
-			}
+		select {
+		case errChannel <- s.cmd.Wait():
+		case <-ctx.Done():
+		}
 	}()
 	select {
-	case err := <- errChannel:
+	case err := <-errChannel:
 		if err != nil {
 			return fmt.Errorf("could not wait for server to finish: %v", err)
 		}

--- a/tika/server_test.go
+++ b/tika/server_test.go
@@ -80,6 +80,31 @@ func TestStart(t *testing.T) {
 	s.Stop()
 }
 
+func TestStartAltTMP(t *testing.T) {
+	path, err := os.Executable() // Use the text executable path as a dummy jar.
+	if err != nil {
+		t.Skip("cannot find current test executable")
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "1.14")
+	}))
+	defer ts.Close()
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("error creating test server: %v", err)
+	}
+
+	s, err := NewServer(path, tsURL.Port())
+	if err != nil {
+		t.Fatalf("NewServer got error: %v", err)
+	}
+	err = s.StartWithAltTmp(context.Background(), ".")
+	if err != nil {
+		t.Fatalf("Start got error: %v", err)
+	}
+	s.Stop()
+}
+
 func bouncyServer(bounce int) *httptest.Server {
 	bounced := 0
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
This PR adds a new function _StartWithAltTmp_ to tika/server.go. It adds a third argument to the exists _Start_ function for passing a path to use as Tika's temporary working directory by adding a -Djava.io.tmpdir flag to the invocation of the tika-server jar. The path is checked to ensure it exists on the file system and returns an error if not. 