### PR TITLE
Adding support for setting java system properties (go-tika #15)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nyudlts/go-tika
+module github.com/google/go-tika
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-tika
+module github.com/nyudlts/go-tika
 
 go 1.11
 

--- a/tika/server.go
+++ b/tika/server.go
@@ -36,6 +36,9 @@ import (
 // from Start.
 // There is no need to create a Server for an already running Tika Server
 // since you can pass its URL directly to a Client.
+// Additional Java system properties can be added to a Taka Server before
+// startup by adding to the JavaProps map
+
 type Server struct {
 	jar       string
 	url       string // url is derived from port.
@@ -131,9 +134,8 @@ func (s *Server) Start(ctx context.Context) error {
 	for k, v := range s.JavaProps {
 		props = append(props, fmt.Sprintf("-D%s=%s", k, v))
 	}
-	propsArgs := strings.Join(props, " ")
 
-	cmd := command("java", append([]string{propsArgs, "-jar", s.jar, "-p", s.port}, s.child.args()...)...)
+	cmd := command("java", append([]string{strings.Join(props, " "), "-jar", s.jar, "-p", s.port}, s.child.args()...)...)
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/tika/server.go
+++ b/tika/server.go
@@ -41,7 +41,7 @@ type Server struct {
 	port      string
 	cmd       *exec.Cmd
 	child     *ChildOptions
-	javaprops map[string]string
+	JavaProps map[string]string
 }
 
 // ChildOptions represent command line parameters that can be used when Tika is run with the -spawnChild option.
@@ -126,14 +126,15 @@ func (s *Server) AddJavaProp(k string, v string) error {
 
 	var m map[string]string
 
-	if (len(s.javaprops)) < 1 {
+	if (len(s.JavaProps)) < 1 {
 		m = make(map[string]string)
 	} else {
-		m = s.javaprops
+		m = s.JavaProps
 	}
 
 	m[k] = v
-	s.javaprops = m
+
+	s.JavaProps = m
 
 	return nil
 }
@@ -150,11 +151,8 @@ func (s *Server) Start(ctx context.Context) error {
 
 	//Check to see if there are any tuples in the servers java props, if so
 	//format and add to the props variable
-
-	if len(s.javaprops) > 0 {
-		for i := range s.javaprops {
-			props = fmt.Sprintf("-D%s=%s ", i, s.javaprops[i])
-		}
+	for i := range s.JavaProps {
+		props = fmt.Sprintf("-D%s=%s ", i, s.JavaProps[i])
 	}
 
 	cmd := command("java", append([]string{props, "-jar", s.jar, "-p", s.port}, s.child.args()...)...)

--- a/tika/server.go
+++ b/tika/server.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"time"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -130,12 +129,14 @@ var command = exec.Command
 // cancelled.
 func (s *Server) Start(ctx context.Context) error {
 
+	//create a slice of Java system properties to be passed to the JVM
 	props := []string{}
 	for k, v := range s.JavaProps {
-		props = append(props, fmt.Sprintf("-D%s=%s", k, v))
+		props = append(props, fmt.Sprintf("-D%s=\"%s\"", k, v))
 	}
 
-	cmd := command("java", append([]string{strings.Join(props, " "), "-jar", s.jar, "-p", s.port}, s.child.args()...)...)
+	args := append(append(props, "-jar", s.jar, "-p", s.port), s.child.args()...)
+	cmd := command("java", args...)
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/tika/server_test.go
+++ b/tika/server_test.go
@@ -250,7 +250,7 @@ func TestAddJavaProps(t *testing.T) {
 	}
 
 	want := 1
-	got := len(s.javaprops)
+	got := len(s.JavaProps)
 
 	if got != want {
 		t.Errorf("wanted %d, got %d", want, got)
@@ -262,7 +262,7 @@ func TestAddJavaProps(t *testing.T) {
 	}
 
 	want = 2
-	got = len(s.javaprops)
+	got = len(s.JavaProps)
 	if got != want {
 		t.Errorf("wanted %d, got %d", want, got)
 	}


### PR DESCRIPTION
This pull requests
- Adds a javaprops map to Server
- Adds a AddJavaProp function to add key-value pairs to a Servers javaprops map
- Modifies the Start() function to check if the javaprops map is not empty, if so it formats key value pairs into system property setters to the java command.
- Adds a test to check that kv pairs are being added to javaprops map