### PR TITLE
Expose Tika http status code in errors returned by client methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-tika
+module github.com/tomyl/go-tika
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tomyl/go-tika
+module github.com/google/go-tika
 
 go 1.11
 

--- a/tika/tika.go
+++ b/tika/tika.go
@@ -29,6 +29,16 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
+// TikaError represents an error response from the Tika server.
+type TikaError struct {
+	// StatusCode is the http status code returned by the Tika server.
+	StatusCode int
+}
+
+func (e TikaError) Error() string {
+	return fmt.Sprintf("response code %d", e.StatusCode)
+}
+
 // Client represents a connection to a Tika Server.
 type Client struct {
 	// url is the URL of the Tika Server, including the port (if necessary), but
@@ -107,7 +117,7 @@ func (c *Client) call(ctx context.Context, input io.Reader, method, path string,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("response code %v", resp.StatusCode)
+		return nil, TikaError{resp.StatusCode}
 	}
 	return ioutil.ReadAll(resp.Body)
 }

--- a/tika/tika.go
+++ b/tika/tika.go
@@ -31,7 +31,7 @@ import (
 
 // ClientError represents an error response from the Tika server.
 type ClientError struct {
-	// StatusCode is the http status code returned by the Tika server.
+	// StatusCode is the HTTP status code returned by the Tika server.
 	StatusCode int
 }
 

--- a/tika/tika.go
+++ b/tika/tika.go
@@ -29,13 +29,13 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
-// TikaError represents an error response from the Tika server.
-type TikaError struct {
+// ClientError represents an error response from the Tika server.
+type ClientError struct {
 	// StatusCode is the http status code returned by the Tika server.
 	StatusCode int
 }
 
-func (e TikaError) Error() string {
+func (e ClientError) Error() string {
 	return fmt.Sprintf("response code %d", e.StatusCode)
 }
 
@@ -117,7 +117,7 @@ func (c *Client) call(ctx context.Context, input io.Reader, method, path string,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, TikaError{resp.StatusCode}
+		return nil, ClientError{resp.StatusCode}
 	}
 	return ioutil.ReadAll(resp.Body)
 }

--- a/tika/tika.go
+++ b/tika/tika.go
@@ -29,7 +29,22 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
-// ClientError represents an error response from the Tika server.
+// ClientError is returned by Client's various parse methods and
+// represents an error response from the Tika server. Example usage:
+//
+//    client := tika.NewClient(nil, tikaURL)
+//    s, err := client.Parse(context.Background(), input)
+//    var tikaErr tika.ClientError
+//    if errors.As(err, &tikaErr) {
+//        switch tikaErr.StatusCode {
+//        case http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity:
+//            // Handle content related error
+//        default:
+//            // Handle possibly intermittent http error
+//        }
+//    } else if err != nil {
+//        // Handle non-http error
+//    }
 type ClientError struct {
 	// StatusCode is the HTTP status code returned by the Tika server.
 	StatusCode int

--- a/tika/tika_test.go
+++ b/tika/tika_test.go
@@ -19,6 +19,7 @@ package tika
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -75,8 +76,9 @@ func TestParse(t *testing.T) {
 
 func TestParseRecursive(t *testing.T) {
 	tests := []struct {
-		response string
-		want     []string
+		response   string
+		want       []string
+		statusCode int
 	}{
 		{
 			response: `[{"X-TIKA:content":"test 1"}]`,
@@ -93,16 +95,34 @@ func TestParseRecursive(t *testing.T) {
 		{
 			response: `[]`,
 		},
+		{
+			statusCode: http.StatusUnprocessableEntity,
+		},
 	}
 	for _, test := range tests {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			fmt.Fprint(w, test.response)
+			if test.statusCode != 0 {
+				w.WriteHeader(test.statusCode)
+			} else {
+				fmt.Fprint(w, test.response)
+			}
 		}))
 		defer ts.Close()
 		c := NewClient(nil, ts.URL)
 		got, err := c.ParseRecursive(context.Background(), nil)
 		if err != nil {
-			t.Errorf("ParseRecursive returned an error: %v, want %v", err, test.want)
+			if test.statusCode != 0 {
+				var tikaErr TikaError
+				if errors.As(err, &tikaErr) {
+					if tikaErr.StatusCode != test.statusCode {
+						t.Errorf("ParseRecursive expected status code %d, got %d", test.statusCode, tikaErr.StatusCode)
+					}
+				} else {
+					t.Errorf("ParseRecursive expected TikaError, got %T", err)
+				}
+			} else {
+				t.Errorf("ParseRecursive returned an error: %v, want %v", err, test.want)
+			}
 			continue
 		}
 		if !reflect.DeepEqual(got, test.want) {

--- a/tika/tika_test.go
+++ b/tika/tika_test.go
@@ -112,7 +112,7 @@ func TestParseRecursive(t *testing.T) {
 		got, err := c.ParseRecursive(context.Background(), nil)
 		if err != nil {
 			if test.statusCode != 0 {
-				var tikaErr TikaError
+				var tikaErr ClientError
 				if errors.As(err, &tikaErr) {
 					if tikaErr.StatusCode != test.statusCode {
 						t.Errorf("ParseRecursive expected status code %d, got %d", test.statusCode, tikaErr.StatusCode)


### PR DESCRIPTION
For users of `tika.Client` it can be useful to be able to differentiate between intermittent errors (http status code 500) and content related errors (e.g. 415 and 422) however currently the client methods just return an opaque error string.

This PR exposes the http status code in the errors returned by the client methods. Example usage:
```go
func doStuff(input io.Reader, tikaURL string) error {
    client := tika.NewClient(nil, tikaURL)
    s, err := client.Parse(context.Background(), input)
    if isUnsupportedFileFormat(err) {
        return nil
    }
    if err != nil {
        return err
    }
   ...
}

func isUnsupportedFileFormat(err error) bool {
    var tikaErr tika.ClientError

    if errors.As(err, &tikaErr) {
        switch tikaErr.StatusCode {
        // Password protected documents yield StatusUnprocessableEntity
        case http.StatusUnsupportedMediaType, http.StatusUnprocessableEntity:
            return true
        default:
            return false
        }
    }

    return false
}
```

I considered going with `type ClientError int` but I thought that a struct is more future proof. Perhaps it could contain information about the exact Tika exception in the future.