### PR TITLE
chore: update tika version in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ To get the binary, run:
 go install github.com/google/go-tika/cmd/tika@latest
 ```
 
-To download the Apache Tika 1.14 Server, check the MD5 sum, start the server in the background, and parse a file, run:
+To download the Apache Tika 1.21 Server, check the MD5 sum, start the server in the background, and parse a file, run:
 
 ```bash
-$(go env GOPATH)/bin/tika -filename /path/to/file/to/parse -download_version 1.14 parse
+$(go env GOPATH)/bin/tika -filename /path/to/file/to/parse -download_version 1.21 parse
 ```
 
-This will store `tika-server-1.14.jar` in your current working directory. If you want to control the output location of the JAR, add a `-server_jar /path/to/save/tika-server.jar` argument.
+This will store `tika-server-1.21.jar` in your current working directory. If you want to control the output location of the JAR, add a `-server_jar /path/to/save/tika-server.jar` argument.
 
 If you already have a downloaded Apache Tika Server JAR, you can specify it with the `-server_jar` flag and it will not be re-downloaded.
 


### PR DESCRIPTION
I noticed that the docs currently suggest downloading version 1.14 of the Apache Tika server, but this causes an error as go-tika only supports version 1.19, 1.20, and 1.21

https://github.com/google/go-tika/blob/65c8946be27ceae272e2e6f475307ba9d54698a9/tika/server.go#L242-L248

It would be great if we could update the docs to recommend the latest supported version, 1.21, or list the compatible versions.